### PR TITLE
STOMP-562 - linker to send single business message to processor

### DIFF
--- a/linker/linker.go
+++ b/linker/linker.go
@@ -136,7 +136,7 @@ func (link Link) OnRelay(aceMessage *rpc.Message) {
 		defer func() {
 			clientRelay.CloseSend()
 		}()
-		err := msgProcessor(ctxWithSpan, aceMessage.GetBusinessMessage(), clientRelay)
+		err := msgProcessor(ctxWithSpan, aceMessage.GetBusinessMessage()[0], clientRelay)
 		if err != nil {
 			tracing.IssueErrorTrace(
 				aceMessage,


### PR DESCRIPTION
This is temporary until the Go SDK is updated to send in Business Message array to the Message Processor